### PR TITLE
Switching to "References" tab after SigMakeDialog

### DIFF
--- a/src/pluginsdk/bridgelist.h
+++ b/src/pluginsdk/bridgelist.h
@@ -54,7 +54,7 @@ public:
     */
     int Count() const
     {
-        if(_listInfo.size != _listInfo.count * sizeof(Type))  //make sure the user is using the correct type.
+        if(_listInfo.size != _listInfo.count * sizeof(Type)) //make sure the user is using the correct type.
             __debugbreak();
         return _listInfo.count;
     }
@@ -88,7 +88,7 @@ public:
     */
     Type & operator[](size_t index) const
     {
-        if(index >= size_t(Count()))  //make sure the out-of-bounds access is caught as soon as possible.
+        if(index >= size_t(Count())) //make sure the out-of-bounds access is caught as soon as possible.
             __debugbreak();
         return Data()[index];
     }
@@ -117,6 +117,14 @@ public:
         }
         else
             listInfo->data = nullptr;
+        return true;
+    }
+
+    static bool Free(const ListInfo* listInfo)
+    {
+        if(!listInfo || listInfo->size != listInfo->count * sizeof(Type) || (listInfo->count && !listInfo->data))
+            return false;
+        BridgeFree(listInfo->data);
         return true;
     }
 

--- a/src/pluginsdk/bridgemain.h
+++ b/src/pluginsdk/bridgemain.h
@@ -5,10 +5,10 @@
 
 #ifndef __cplusplus
 #include <stdbool.h>
+#define DEFAULT_PARAM(name, value) name
+#else
+#define DEFAULT_PARAM(name, value) name = value
 #endif
-
-//list structure (and C++ wrapper)
-#include "bridgelist.h"
 
 //default structure alignments forced
 #ifdef _WIN64
@@ -43,21 +43,99 @@ extern "C"
 #define DBG_VERSION 25
 
 //Bridge functions
+
+/// <summary>
+/// Initialize the bridge.
+/// </summary>
+/// <returns>On error it returns a non-null error message.</returns>
 BRIDGE_IMPEXP const wchar_t* BridgeInit();
+
+/// <summary>
+/// Start the bridge.
+/// </summary>
+/// <returns>On error it returns a non-null error message.</returns>
 BRIDGE_IMPEXP const wchar_t* BridgeStart();
+
+/// <summary>
+/// Allocate buffer. Use BridgeFree to free the buffer.
+/// </summary>
+/// <param name="size">Size in bytes of the buffer to allocate.</param>
+/// <returns>A pointer to the allocated buffer. This function will trigger a crash dump if unsuccessful.</returns>
 BRIDGE_IMPEXP void* BridgeAlloc(size_t size);
+
+/// <summary>
+/// Free buffer allocated by BridgeAlloc.
+/// </summary>
+/// <param name="ptr">Buffer to free.</param>
 BRIDGE_IMPEXP void BridgeFree(void* ptr);
+
+/// <summary>
+/// Get a string setting from the in-memory setting store.
+/// </summary>
+/// <param name="section">Section the setting is in. Cannot be null.</param>
+/// <param name="key">Setting key (name). Cannot be null.</param>
+/// <param name="value">Output buffer for the value. Should be of MAX_SETTING_SIZE. Cannot be null.</param>
+/// <returns>True if the setting was found and copied in the value parameter.</returns>
 BRIDGE_IMPEXP bool BridgeSettingGet(const char* section, const char* key, char* value);
+
+/// <summary>
+/// Get an integer setting from the in-memory setting store.
+/// </summary>
+/// <param name="section">Section the setting is in. Cannot be null.</param>
+/// <param name="key">Setting key (name). Cannot be null.</param>
+/// <param name="value">Output value.</param>
+/// <returns>True if the setting was found and successfully converted to an integer.</returns>
 BRIDGE_IMPEXP bool BridgeSettingGetUint(const char* section, const char* key, duint* value);
+
+/// <summary>
+/// Set a string setting in the in-memory setting store.
+/// </summary>
+/// <param name="section">Section the setting is in. Cannot be null.</param>
+/// <param name="key">Setting key (name). Set to null to clear the whole section.</param>
+/// <param name="value">New setting value. Set to null to remove the key from the section.</param>
+/// <returns>True if the operation was successful.</returns>
 BRIDGE_IMPEXP bool BridgeSettingSet(const char* section, const char* key, const char* value);
+
+/// <summary>
+/// Set an integer setting in the in-memory setting store.
+/// </summary>
+/// <param name="section">Section the setting is in. Cannot be null.</param>
+/// <param name="key">Setting key (name). Set to null to clear the whole section.</param>
+/// <param name="value">New setting value.</param>
+/// <returns>True if the operation was successful.</returns>
 BRIDGE_IMPEXP bool BridgeSettingSetUint(const char* section, const char* key, duint value);
+
+/// <summary>
+/// Flush the in-memory setting store to disk.
+/// </summary>
+/// <returns></returns>
 BRIDGE_IMPEXP bool BridgeSettingFlush();
+
+/// <summary>
+/// Read the in-memory setting store from disk.
+/// </summary>
+/// <param name="errorLine">Line where the error occurred. Set to null to ignore this.</param>
+/// <returns>True if the setting were read and parsed correctly.</returns>
 BRIDGE_IMPEXP bool BridgeSettingRead(int* errorLine);
+
+/// <summary>
+/// Get the debugger version.
+/// </summary>
+/// <returns>25</returns>
 BRIDGE_IMPEXP int BridgeGetDbgVersion();
+
+/// <summary>
+/// Checks if the current process is elevated.
+/// </summary>
+/// <returns>true if the process is elevated, false otherwise.</returns>
+BRIDGE_IMPEXP bool BridgeIsProcessElevated();
 
 #ifdef __cplusplus
 }
 #endif
+
+//list structure (and C++ wrapper)
+#include "bridgelist.h"
 
 #include "bridgegraph.h"
 
@@ -107,13 +185,14 @@ typedef enum
 
 typedef enum
 {
-    flagmodule = 1,
-    flaglabel = 2,
-    flagcomment = 4,
-    flagbookmark = 8,
-    flagfunction = 16,
-    flagloop = 32,
-    flagargs = 64
+    flagmodule = 0x1,
+    flaglabel = 0x2,
+    flagcomment = 0x4,
+    flagbookmark = 0x8,
+    flagfunction = 0x10,
+    flagloop = 0x20,
+    flagargs = 0x40,
+    flagNoFuncOffset = 0x80
 } ADDRINFOFLAGS;
 
 typedef enum
@@ -141,7 +220,8 @@ typedef enum
     LOOP_BEGIN,
     LOOP_MIDDLE,
     LOOP_ENTRY,
-    LOOP_END
+    LOOP_END,
+    LOOP_SINGLE
 } LOOPTYPE;
 
 //order by most important type last
@@ -228,7 +308,17 @@ typedef enum
     DBG_ARGUMENT_OVERLAPS,          // param1=FUNCTION* info,            param2=unused
     DBG_ARGUMENT_ADD,               // param1=FUNCTION* info,            param2=unused
     DBG_ARGUMENT_DEL,               // param1=FUNCTION* info,            param2=unused
-    DBG_GET_WATCH_LIST              // param1=ListOf(WATCHINFO),         param2=unused
+    DBG_GET_WATCH_LIST,             // param1=ListOf(WATCHINFO),         param2=unused
+    DBG_SELCHANGED,                 // param1=hWindow,                   param2=VA
+    DBG_GET_PROCESS_HANDLE,         // param1=unused,                    param2=unused
+    DBG_GET_THREAD_HANDLE,          // param1=unused,                    param2=unused
+    DBG_GET_PROCESS_ID,             // param1=unused,                    param2=unused
+    DBG_GET_THREAD_ID,              // param1=unused,                    param2=unused
+    DBG_GET_PEB_ADDRESS,            // param1=DWORD ProcessId,           param2=unused
+    DBG_GET_TEB_ADDRESS,            // param1=DWORD ThreadId,            param2=unused
+    DBG_ANALYZE_FUNCTION,           // param1=BridgeCFGraphList* graph,  param2=duint entry
+    DBG_MENU_PREPARE,               // param1=int hMenu,                 param2=unused
+    DBG_GET_SYMBOL_INFO,            // param1=void* symbol,              param2=SYMBOLINFO* info
 } DBGMSG;
 
 typedef enum
@@ -331,7 +421,9 @@ typedef enum
     size_byte = 1,
     size_word = 2,
     size_dword = 4,
-    size_qword = 8
+    size_qword = 8,
+    size_xmmword = 16,
+    size_ymmword = 32
 } MEMORY_SIZE;
 
 typedef enum
@@ -377,12 +469,56 @@ typedef enum
     MODE_UNCHANGED // alert if expression is not changed
 } WATCHDOGMODE;
 
+typedef enum
+{
+    hw_access,
+    hw_write,
+    hw_execute
+} BPHWTYPE;
+
+typedef enum
+{
+    mem_access,
+    mem_read,
+    mem_write,
+    mem_execute
+} BPMEMTYPE;
+
+typedef enum
+{
+    dll_load = 1,
+    dll_unload,
+    dll_all
+} BPDLLTYPE;
+
+typedef enum
+{
+    ex_firstchance = 1,
+    ex_secondchance,
+    ex_all
+} BPEXTYPE;
+
+typedef enum
+{
+    hw_byte,
+    hw_word,
+    hw_dword,
+    hw_qword
+} BPHWSIZE;
+
+typedef enum
+{
+    sym_import,
+    sym_export,
+    sym_symbol
+} SYMBOLTYPE;
+
 //Debugger typedefs
 typedef MEMORY_SIZE VALUE_SIZE;
-typedef struct SYMBOLINFO_ SYMBOLINFO;
+
 typedef struct DBGFUNCTIONS_ DBGFUNCTIONS;
 
-typedef void (*CBSYMBOLENUM)(SYMBOLINFO* symbol, void* user);
+typedef bool (*CBSYMBOLENUM)(const struct SYMBOLPTR_* symbol, void* user);
 
 //Debugger structs
 typedef struct
@@ -408,6 +544,8 @@ typedef struct
     char mod[MAX_MODULE_SIZE];
     unsigned short slot;
     // extended part
+    unsigned char typeEx; //BPHWTYPE/BPMEMTYPE/BPDLLTYPE/BPEXTYPE
+    unsigned char hwSize; //BPHWSIZE
     unsigned int hitCount;
     bool fastResume;
     bool silent;
@@ -448,9 +586,9 @@ typedef struct
     int depth; //IN
     duint start; //OUT
     duint end; //OUT
+    duint instrcount; //OUT
 } LOOP;
 
-#ifndef _NO_ADDRINFO
 typedef struct
 {
     int flags; //ADDRINFOFLAGS (IN)
@@ -461,16 +599,18 @@ typedef struct
     FUNCTION function;
     LOOP loop;
     FUNCTION args;
-} ADDRINFO;
-#endif
+} BRIDGE_ADDRINFO;
 
-struct SYMBOLINFO_
+typedef struct SYMBOLINFO_
 {
     duint addr;
     char* decoratedSymbol;
     char* undecoratedSymbol;
-    bool isImported;
-};
+    SYMBOLTYPE type;
+    bool freeDecorated;
+    bool freeUndecorated;
+    DWORD ordinal;
+} SYMBOLINFO;
 
 typedef struct
 {
@@ -525,7 +665,7 @@ typedef struct
     bool C2;
     bool C1;
     bool C0;
-    bool IR;
+    bool ES;
     bool SF;
     bool P;
     bool U;
@@ -639,6 +779,12 @@ typedef struct
 
 typedef struct
 {
+    DWORD code;
+    char name[128];
+} LASTSTATUS;
+
+typedef struct
+{
     REGISTERCONTEXT regcontext;
     FLAGS flags;
     X87FPUREGISTER x87FPURegisters[8];
@@ -647,6 +793,7 @@ typedef struct
     X87STATUSWORDFIELDS x87StatusWordFields;
     X87CONTROLWORDFIELDS x87ControlWordFields;
     LASTERROR lastError;
+    LASTSTATUS lastStatus;
 } REGDUMP;
 
 typedef struct
@@ -763,14 +910,39 @@ typedef struct
     XREF_RECORD* references;
 } XREF_INFO;
 
+typedef struct SYMBOLPTR_
+{
+    duint modbase;
+    const void* symbol;
+} SYMBOLPTR;
+
 //Debugger functions
 BRIDGE_IMPEXP const char* DbgInit();
 BRIDGE_IMPEXP void DbgExit();
-BRIDGE_IMPEXP bool DbgMemRead(duint va, unsigned char* dest, duint size);
-BRIDGE_IMPEXP bool DbgMemWrite(duint va, const unsigned char* src, duint size);
+BRIDGE_IMPEXP bool DbgMemRead(duint va, void* dest, duint size);
+BRIDGE_IMPEXP bool DbgMemWrite(duint va, const void* src, duint size);
 BRIDGE_IMPEXP duint DbgMemGetPageSize(duint base);
 BRIDGE_IMPEXP duint DbgMemFindBaseAddr(duint addr, duint* size);
+
+/// <summary>
+/// Asynchronously execute a debugger command by adding it to the command queue.
+/// Note: the command may not have completed before this call returns. Use this
+/// function if you don't care when the command gets executed.
+///
+/// Example: DbgCmdExec("ClearLog")
+/// </summary>
+/// <param name="cmd">The command to execute.</param>
+/// <returns>True if the command was successfully submitted to the command queue. False if the submission failed.</returns>
 BRIDGE_IMPEXP bool DbgCmdExec(const char* cmd);
+
+/// <summary>
+/// Performs synchronous execution of a debugger command. This function call only
+/// returns after the command has completed.
+///
+/// Example: DbgCmdExecDirect("loadlib advapi32.dll")
+/// </summary>
+/// <param name="cmd">The command to execute.</param>
+/// <returns>True if the command executed successfully, False if there was a problem.</returns>
 BRIDGE_IMPEXP bool DbgCmdExecDirect(const char* cmd);
 BRIDGE_IMPEXP bool DbgMemMap(MEMMAP* memmap);
 BRIDGE_IMPEXP bool DbgIsValidExpression(const char* expression);
@@ -788,7 +960,7 @@ BRIDGE_IMPEXP void DbgClearBookmarkRange(duint start, duint end);
 BRIDGE_IMPEXP bool DbgGetModuleAt(duint addr, char* text);
 BRIDGE_IMPEXP BPXTYPE DbgGetBpxTypeAt(duint addr);
 BRIDGE_IMPEXP duint DbgValFromString(const char* string);
-BRIDGE_IMPEXP bool DbgGetRegDump(REGDUMP* regdump);
+BRIDGE_IMPEXP bool DbgGetRegDumpEx(REGDUMP* regdump, size_t size);
 BRIDGE_IMPEXP bool DbgValToString(const char* string, duint value);
 BRIDGE_IMPEXP bool DbgMemIsValidReadPtr(duint addr);
 BRIDGE_IMPEXP int DbgGetBpList(BPXTYPE type, BPMAP* list);
@@ -850,7 +1022,7 @@ BRIDGE_IMPEXP bool DbgWinEventGlobal(MSG* message);
 BRIDGE_IMPEXP bool DbgIsRunning();
 BRIDGE_IMPEXP duint DbgGetTimeWastedCounter();
 BRIDGE_IMPEXP ARGTYPE DbgGetArgTypeAt(duint addr);
-BRIDGE_IMPEXP void* DbgGetEncodeTypeBuffer(duint addr);
+BRIDGE_IMPEXP void* DbgGetEncodeTypeBuffer(duint addr, duint* size);
 BRIDGE_IMPEXP void DbgReleaseEncodeTypeBuffer(void* buffer);
 BRIDGE_IMPEXP ENCODETYPE DbgGetEncodeTypeAt(duint addr, duint size);
 BRIDGE_IMPEXP duint DbgGetEncodeSizeAt(duint addr, duint codesize);
@@ -858,19 +1030,40 @@ BRIDGE_IMPEXP bool DbgSetEncodeType(duint addr, duint size, ENCODETYPE type);
 BRIDGE_IMPEXP void DbgDelEncodeTypeRange(duint start, duint end);
 BRIDGE_IMPEXP void DbgDelEncodeTypeSegment(duint start);
 BRIDGE_IMPEXP bool DbgGetWatchList(ListOf(WATCHINFO) list);
+BRIDGE_IMPEXP void DbgSelChanged(int hWindow, duint VA);
+BRIDGE_IMPEXP HANDLE DbgGetProcessHandle();
+BRIDGE_IMPEXP HANDLE DbgGetThreadHandle();
+BRIDGE_IMPEXP DWORD DbgGetProcessId();
+BRIDGE_IMPEXP DWORD DbgGetThreadId();
+BRIDGE_IMPEXP duint DbgGetPebAddress(DWORD ProcessId);
+BRIDGE_IMPEXP duint DbgGetTebAddress(DWORD ThreadId);
+BRIDGE_IMPEXP bool DbgAnalyzeFunction(duint entry, BridgeCFGraphList* graph);
+BRIDGE_IMPEXP duint DbgEval(const char* expression, bool* DEFAULT_PARAM(success, nullptr));
+BRIDGE_IMPEXP void DbgGetSymbolInfo(const SYMBOLPTR* symbolptr, SYMBOLINFO* info);
 
 //Gui defines
-#define GUI_PLUGIN_MENU 0
-#define GUI_DISASM_MENU 1
-#define GUI_DUMP_MENU 2
-#define GUI_STACK_MENU 3
+typedef enum
+{
+    GUI_PLUGIN_MENU,
+    GUI_DISASM_MENU,
+    GUI_DUMP_MENU,
+    GUI_STACK_MENU,
+    GUI_GRAPH_MENU,
+    GUI_MEMMAP_MENU,
+    GUI_SYMMOD_MENU,
+} GUIMENUTYPE;
 
-#define GUI_DISASSEMBLY 0
-#define GUI_DUMP 1
-#define GUI_STACK 2
-#define GUI_GRAPH 3
-#define GUI_MEMMAP 4
-#define GUI_SYMMOD 5
+BRIDGE_IMPEXP void DbgMenuPrepare(GUIMENUTYPE hMenu);
+
+typedef enum
+{
+    GUI_DISASSEMBLY,
+    GUI_DUMP,
+    GUI_STACK,
+    GUI_GRAPH,
+    GUI_MEMMAP,
+    GUI_SYMMOD,
+} GUISELECTIONTYPE;
 
 #define GUI_MAX_LINE_SIZE 65536
 #define GUI_MAX_DISASSEMBLY_SIZE 2048
@@ -921,8 +1114,8 @@ typedef enum
     GUI_MENU_ADD_ENTRY,             // param1=int hMenu,            param2=const char* title
     GUI_MENU_ADD_SEPARATOR,         // param1=int hMenu,            param2=unused
     GUI_MENU_CLEAR,                 // param1=int hMenu,            param2=unused
-    GUI_SELECTION_GET,              // param1=int hWindow,          param2=SELECTIONDATA* selection
-    GUI_SELECTION_SET,              // param1=int hWindow,          param2=const SELECTIONDATA* selection
+    GUI_SELECTION_GET,              // param1=GUISELECTIONTYPE,     param2=SELECTIONDATA* selection
+    GUI_SELECTION_SET,              // param1=GUISELECTIONTYPE,     param2=const SELECTIONDATA* selection
     GUI_GETLINE_WINDOW,             // param1=const char* title,    param2=char* text
     GUI_AUTOCOMPLETE_ADDCMD,        // param1=const char* cmd,      param2=ununsed
     GUI_AUTOCOMPLETE_DELCMD,        // param1=const char* cmd,      param2=ununsed
@@ -937,14 +1130,14 @@ typedef enum
     GUI_SYMBOL_REFRESH_CURRENT,     // param1=unused,               param2=unused
     GUI_UPDATE_MEMORY_VIEW,         // param1=unused,               param2=unused
     GUI_REF_INITIALIZE,             // param1=const char* name,     param2=unused
-    GUI_LOAD_SOURCE_FILE,           // param1=const char* path,     param2=line
+    GUI_LOAD_SOURCE_FILE,           // param1=const char* path,     param2=duint addr
     GUI_MENU_SET_ICON,              // param1=int hMenu,            param2=ICONINFO*
     GUI_MENU_SET_ENTRY_ICON,        // param1=int hEntry,           param2=ICONINFO*
     GUI_SHOW_CPU,                   // param1=unused,               param2=unused
     GUI_ADD_QWIDGET_TAB,            // param1=QWidget*,             param2=unused
     GUI_SHOW_QWIDGET_TAB,           // param1=QWidget*,             param2=unused
     GUI_CLOSE_QWIDGET_TAB,          // param1=QWidget*,             param2=unused
-    GUI_EXECUTE_ON_GUI_THREAD,      // param1=GUICALLBACK,          param2=unused
+    GUI_EXECUTE_ON_GUI_THREAD,      // param1=GUICALLBACKEX cb,     param2=void* userdata
     GUI_UPDATE_TIME_WASTED_COUNTER, // param1=unused,               param2=unused
     GUI_SET_GLOBAL_NOTES,           // param1=const char* text,     param2=unused
     GUI_GET_GLOBAL_NOTES,           // param1=char** text,          param2=unused
@@ -965,13 +1158,40 @@ typedef enum
     GUI_ADD_FAVOURITE_COMMAND,      // param1=const char* command   param2=const char* shortcut
     GUI_SET_FAVOURITE_TOOL_SHORTCUT,// param1=const char* name      param2=const char* shortcut
     GUI_FOLD_DISASSEMBLY,           // param1=duint startAddress    param2=duint length
-    GUI_SELECT_IN_MEMORY_MAP        // param1=duint addr,           param2=unused
+    GUI_SELECT_IN_MEMORY_MAP,       // param1=duint addr,           param2=unused
+    GUI_GET_ACTIVE_VIEW,            // param1=ACTIVEVIEW*,          param2=unused
+    GUI_MENU_SET_ENTRY_CHECKED,     // param1=int hEntry,           param2=bool checked
+    GUI_ADD_INFO_LINE,              // param1=const char* infoline, param2=unused
+    GUI_PROCESS_EVENTS,             // param1=unused,               param2=unused
+    GUI_TYPE_ADDNODE,               // param1=void* parent,         param2=TYPEDESCRIPTOR* type
+    GUI_TYPE_CLEAR,                 // param1=unused,               param2=unused
+    GUI_UPDATE_TYPE_WIDGET,         // param1=unused,               param2=unused
+    GUI_CLOSE_APPLICATION,          // param1=unused,               param2=unused
+    GUI_MENU_SET_VISIBLE,           // param1=int hMenu,            param2=bool visible
+    GUI_MENU_SET_ENTRY_VISIBLE,     // param1=int hEntry,           param2=bool visible
+    GUI_MENU_SET_NAME,              // param1=int hMenu,            param2=const char* name
+    GUI_MENU_SET_ENTRY_NAME,        // param1=int hEntry,           param2=const char* name
+    GUI_FLUSH_LOG,                  // param1=unused,               param2=unused
+    GUI_MENU_SET_ENTRY_HOTKEY,      // param1=int hEntry,           param2=const char* hack
+    GUI_REF_SEARCH_GETROWCOUNT,     // param1=unused,               param2=unused
+    GUI_REF_SEARCH_GETCELLCONTENT,  // param1=int row,              param2=int col
+    GUI_MENU_REMOVE,                // param1=int hEntryMenu,       param2=unused
+    GUI_REF_ADDCOMMAND,             // param1=const char* title,    param2=const char* command
+    GUI_OPEN_TRACE_FILE,            // param1=const char* file name,param2=unused
+    GUI_UPDATE_TRACE_BROWSER,       // param1=unused,               param2=unused
+    GUI_INVALIDATE_SYMBOL_SOURCE,   // param1=duint base,           param2=unused
+    GUI_GET_CURRENT_GRAPH,          // param1=BridgeCFGraphList*,   param2=unused
+    GUI_SHOW_REF,                   // param1=unused,               param2=unused
 } GUIMSG;
 
 //GUI Typedefs
+struct _TYPEDESCRIPTOR;
+
 typedef void (*GUICALLBACK)();
+typedef void (*GUICALLBACKEX)(void*);
 typedef bool (*GUISCRIPTEXECUTE)(const char* text);
 typedef void (*GUISCRIPTCOMPLETER)(const char* text, char** entries, int* entryCount);
+typedef bool (*TYPETOSTRING)(const struct _TYPEDESCRIPTOR* type, char* dest, size_t* destCount); //don't change destCount for final failure
 
 //GUI structures
 typedef struct
@@ -1001,11 +1221,33 @@ typedef struct
     GUISCRIPTCOMPLETER completeCommand;
 } SCRIPTTYPEINFO;
 
+typedef struct
+{
+    void* titleHwnd;
+    void* classHwnd;
+    char title[MAX_STRING_SIZE];
+    char className[MAX_STRING_SIZE];
+} ACTIVEVIEW;
+
+typedef struct _TYPEDESCRIPTOR
+{
+    bool expanded; //is the type node expanded?
+    bool reverse; //big endian?
+    const char* name; //type name (int b)
+    duint addr; //virtual address
+    duint offset; //offset to addr for the actual location
+    int id; //type id
+    int size; //sizeof(type)
+    TYPETOSTRING callback; //convert to string
+    void* userdata; //user data
+} TYPEDESCRIPTOR;
+
 //GUI functions
 //code page is utf8
 BRIDGE_IMPEXP const char* GuiTranslateText(const char* Source);
 BRIDGE_IMPEXP void GuiDisasmAt(duint addr, duint cip);
 BRIDGE_IMPEXP void GuiSetDebugState(DBGSTATE state);
+BRIDGE_IMPEXP void GuiSetDebugStateFast(DBGSTATE state);
 BRIDGE_IMPEXP void GuiAddLogMessage(const char* msg);
 BRIDGE_IMPEXP void GuiLogClear();
 BRIDGE_IMPEXP void GuiUpdateAllViews();
@@ -1032,10 +1274,12 @@ BRIDGE_IMPEXP void GuiSymbolRefreshCurrent();
 BRIDGE_IMPEXP void GuiReferenceAddColumn(int width, const char* title);
 BRIDGE_IMPEXP void GuiReferenceSetRowCount(int count);
 BRIDGE_IMPEXP int GuiReferenceGetRowCount();
+BRIDGE_IMPEXP int GuiReferenceSearchGetRowCount();
 BRIDGE_IMPEXP void GuiReferenceDeleteAllColumns();
 BRIDGE_IMPEXP void GuiReferenceInitialize(const char* name);
 BRIDGE_IMPEXP void GuiReferenceSetCellContent(int row, int col, const char* str);
-BRIDGE_IMPEXP const char* GuiReferenceGetCellContent(int row, int col);
+BRIDGE_IMPEXP char* GuiReferenceGetCellContent(int row, int col);
+BRIDGE_IMPEXP char* GuiReferenceSearchGetCellContent(int row, int col);
 BRIDGE_IMPEXP void GuiReferenceReloadData();
 BRIDGE_IMPEXP void GuiReferenceSetSingleSelection(int index, bool scroll);
 BRIDGE_IMPEXP void GuiReferenceSetProgress(int progress);
@@ -1053,8 +1297,9 @@ BRIDGE_IMPEXP int GuiMenuAdd(int hMenu, const char* title);
 BRIDGE_IMPEXP int GuiMenuAddEntry(int hMenu, const char* title);
 BRIDGE_IMPEXP void GuiMenuAddSeparator(int hMenu);
 BRIDGE_IMPEXP void GuiMenuClear(int hMenu);
-BRIDGE_IMPEXP bool GuiSelectionGet(int hWindow, SELECTIONDATA* selection);
-BRIDGE_IMPEXP bool GuiSelectionSet(int hWindow, const SELECTIONDATA* selection);
+BRIDGE_IMPEXP void GuiMenuRemove(int hEntryMenu);
+BRIDGE_IMPEXP bool GuiSelectionGet(GUISELECTIONTYPE hWindow, SELECTIONDATA* selection);
+BRIDGE_IMPEXP bool GuiSelectionSet(GUISELECTIONTYPE hWindow, const SELECTIONDATA* selection);
 BRIDGE_IMPEXP bool GuiGetLineWindow(const char* title, char* text);
 BRIDGE_IMPEXP void GuiAutoCompleteAddCmd(const char* cmd);
 BRIDGE_IMPEXP void GuiAutoCompleteDelCmd(const char* cmd);
@@ -1065,9 +1310,15 @@ BRIDGE_IMPEXP void GuiRepaintTableView();
 BRIDGE_IMPEXP void GuiUpdatePatches();
 BRIDGE_IMPEXP void GuiUpdateCallStack();
 BRIDGE_IMPEXP void GuiUpdateSEHChain();
-BRIDGE_IMPEXP void GuiLoadSourceFile(const char* path, int line);
+BRIDGE_IMPEXP void GuiLoadSourceFileEx(const char* path, duint addr);
 BRIDGE_IMPEXP void GuiMenuSetIcon(int hMenu, const ICONDATA* icon);
 BRIDGE_IMPEXP void GuiMenuSetEntryIcon(int hEntry, const ICONDATA* icon);
+BRIDGE_IMPEXP void GuiMenuSetEntryChecked(int hEntry, bool checked);
+BRIDGE_IMPEXP void GuiMenuSetVisible(int hMenu, bool visible);
+BRIDGE_IMPEXP void GuiMenuSetEntryVisible(int hEntry, bool visible);
+BRIDGE_IMPEXP void GuiMenuSetName(int hMenu, const char* name);
+BRIDGE_IMPEXP void GuiMenuSetEntryName(int hEntry, const char* name);
+BRIDGE_IMPEXP void GuiMenuSetEntryHotkey(int hEntry, const char* hack);
 BRIDGE_IMPEXP void GuiShowCpu();
 BRIDGE_IMPEXP void GuiAddQWidgetTab(void* qWidget);
 BRIDGE_IMPEXP void GuiShowQWidgetTab(void* qWidget);
@@ -1087,8 +1338,8 @@ BRIDGE_IMPEXP void GuiFocusView(int hWindow);
 BRIDGE_IMPEXP bool GuiIsUpdateDisabled();
 BRIDGE_IMPEXP void GuiUpdateEnable(bool updateNow);
 BRIDGE_IMPEXP void GuiUpdateDisable();
-BRIDGE_IMPEXP void GuiLoadGraph(BridgeCFGraphList* graph, duint addr);
-BRIDGE_IMPEXP bool GuiGraphAt(duint addr);
+BRIDGE_IMPEXP bool GuiLoadGraph(BridgeCFGraphList* graph, duint addr);
+BRIDGE_IMPEXP duint GuiGraphAt(duint addr);
 BRIDGE_IMPEXP void GuiUpdateGraphView();
 BRIDGE_IMPEXP void GuiDisableLog();
 BRIDGE_IMPEXP void GuiEnableLog();
@@ -1097,6 +1348,21 @@ BRIDGE_IMPEXP void GuiAddFavouriteCommand(const char* name, const char* shortcut
 BRIDGE_IMPEXP void GuiSetFavouriteToolShortcut(const char* name, const char* shortcut);
 BRIDGE_IMPEXP void GuiFoldDisassembly(duint startAddress, duint length);
 BRIDGE_IMPEXP void GuiSelectInMemoryMap(duint addr);
+BRIDGE_IMPEXP void GuiGetActiveView(ACTIVEVIEW* activeView);
+BRIDGE_IMPEXP void GuiAddInfoLine(const char* infoLine);
+BRIDGE_IMPEXP void GuiProcessEvents();
+BRIDGE_IMPEXP void* GuiTypeAddNode(void* parent, const TYPEDESCRIPTOR* type);
+BRIDGE_IMPEXP bool GuiTypeClear();
+BRIDGE_IMPEXP void GuiUpdateTypeWidget();
+BRIDGE_IMPEXP void GuiCloseApplication();
+BRIDGE_IMPEXP void GuiFlushLog();
+BRIDGE_IMPEXP void GuiReferenceAddCommand(const char* title, const char* command);
+BRIDGE_IMPEXP void GuiUpdateTraceBrowser();
+BRIDGE_IMPEXP void GuiOpenTraceFile(const char* fileName);
+BRIDGE_IMPEXP void GuiInvalidateSymbolSource(duint base);
+BRIDGE_IMPEXP void GuiExecuteOnGuiThreadEx(GUICALLBACKEX cbGuiThread, void* userdata);
+BRIDGE_IMPEXP void GuiGetCurrentGraph(BridgeCFGraphList* graphList);
+BRIDGE_IMPEXP void GuiShowReferences();
 
 #ifdef __cplusplus
 }

--- a/src/sigmake/Dialog/SigMakeDialog.cpp
+++ b/src/sigmake/Dialog/SigMakeDialog.cpp
@@ -128,6 +128,7 @@ void MakeSigDialogExecute(HWND hwndDlg)
 	GuiReferenceAddColumn(100, "Disassembly");
 	GuiReferenceSetRowCount((int)results.size());
 	GuiReferenceSetProgress(0);
+	GuiShowReferences();
 
 	int i = 0;
 	for (auto& match : results)


### PR DESCRIPTION
I've updated the plugin sdk and added the "GuiShowReferences" call after closing the SigMakeDialog, similar to [this ](https://github.com/Nukem9/SigMake/pull/2) PR in another repo.

BTW. I didn't push the updated .lib, because I'm not sure which extact version of compiler you used to compile another .libs in this repo and I don't want to make mess, however if you want to I can include them.